### PR TITLE
Support for Plexamp headless player

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,7 +173,7 @@ Options
   -r <gpio>  I2C/SPI reset GPIO number, if needed (default: 25)
   -D <gpio>  SPI DC GPIO number (default: 24)
   -S <num>   SPI CS number (default: 0)
-  -p <plyr>  Player: mpd, moode, volumio, runeaudio (default: detected)
+  -p <plyr>  Player: mpd, moode, volumio, runeaudio, plexamp (default: detected)
 Example :
 %s -o 6 use a %s OLED
 )",
@@ -346,7 +346,7 @@ void OledOpts::process_command_line(int argc, char **argv)
       break;
 
     case 'p': {
-      // const char *params = "mpd|moode|volumio|runeaudio\n";
+      // const char *params = "mpd|moode|volumio|runeaudio|plexamp\n";
       string params = Player::all_names("|");
       string arg_id;
       if (!get_arg_id(optarg, &arg_id, params.c_str()))

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -35,7 +35,7 @@
 using std::string;
 
 std::vector<std::string> Player::name_strs = {"mpd", "moode", "volumio",
-                                              "runeaudio", "unknown"};
+                                              "runeaudio","plexamp", "unknown"};
 
 namespace {
 bool file_exists(const std::string &name)
@@ -54,6 +54,8 @@ void Player::init_detect()
     name = Player::Name::volumio;
   else if (file_exists("/srv/http/command/rune_shutdown"))
     name = Player::Name::runeaudio;
+  else if (file_exists("/home/claudio/plexamp/js/index.js"))
+    name = Player::Name::plexamp;
   else if (system("which mpd > /dev/null 2>&1") == 0) // check for mpd
     name = Player::Name::mpd;
   else

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -48,13 +48,15 @@ bool file_exists(const std::string &name)
 void Player::init_detect()
 {
   // Check for files associated with a player OS
+  string home( getenv( "HOME" ) );
+  
   if (file_exists("/var/www/command/moode.php"))
     name = Player::Name::moode;
   else if (file_exists("/volumio"))
     name = Player::Name::volumio;
   else if (file_exists("/srv/http/command/rune_shutdown"))
     name = Player::Name::runeaudio;
-  else if (file_exists("/home/claudio/plexamp/js/index.js"))
+  else if (file_exists(home + "/plexamp/js/index.js"))
     name = Player::Name::plexamp;
   else if (system("which mpd > /dev/null 2>&1") == 0) // check for mpd
     name = Player::Name::mpd;

--- a/src/player.h
+++ b/src/player.h
@@ -37,7 +37,7 @@
 class Player {
 public:
   // name values here, names strings define in cpp file
-  enum Name { mpd, moode, volumio, runeaudio, unknown };
+  enum Name { mpd, moode, volumio, runeaudio, plexamp, unknown };
   static std::vector<std::string> name_strs;
 
 private:

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -206,3 +206,13 @@ string msg_str(const char *fmt, ...)
   vsnprintf(message, MSG_SZ - 1, fmt, args);
   return message;
 }
+
+string get_str_between_two_str(const string &s, const string &start_delim,
+                               const string &end_delim)
+{
+  unsigned first_delim_pos = s.find(start_delim);
+  unsigned end_pos_of_first_delim = first_delim_pos + start_delim.length() + 1;
+  unsigned last_delim_pos = s.find_first_of(end_delim, end_pos_of_first_delim);
+  return s.substr(end_pos_of_first_delim,
+                  last_delim_pos - end_pos_of_first_delim);
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -140,4 +140,13 @@ char *clear_extra_whitespace(char *str);
  * \return The converted string. */
 std::string msg_str(const char *fmt, ...);
 
+/// Extract a substring between two delimiters
+/** Extracts a substring between a start delimiter and the first occurrence of
+ * the end delimiter encountered after the first delimiter \param s the string
+ * to extract from \param start_delim the start delimiter \param end_delim the
+ * end delimiter \return Text between the two delimiter strings. */
+std::string get_str_between_two_str(const std::string &s,
+                                    const std::string &start_delim,
+                                    const std::string &end_delim);
+
 #endif // UTILS_H


### PR DESCRIPTION
Hi,
I added support for Plexamp, a music client for Plex available in a headless version for raspberry pi and similar. It doesn't use MPD but the playback information are exposed by the web server.